### PR TITLE
ABV

### DIFF
--- a/lib/brewscribe/recipe.rb
+++ b/lib/brewscribe/recipe.rb
@@ -61,5 +61,13 @@ module Brewscribe
       self.carb = Carbonation.from_data self.carb
       self.style = Style.from_data self.style
     end
+
+    def abv
+      (((1.05 * (self.og_measured - self.fg_measured)) / self.fg_measured) / 0.79 * 100).round(2)
+    end
+
+    def abw
+      abv * 0.79336
+    end
   end
 end

--- a/spec/recipe_spec.rb
+++ b/spec/recipe_spec.rb
@@ -71,4 +71,10 @@ describe Brewscribe::Recipe do
   it 'should set stir_plate to boolean' do
     [true, false].should include subject.stir_plate
   end
+
+  context 'calculation methods' do
+    its(:og_measured) { should == 1.046 }
+    its(:fg_measured) { should == 1.010 }
+    its(:abv) { should == 4.74 }
+  end
 end


### PR DESCRIPTION
It would be nice if there was a helper method to retrieve ABV. I'm currently doing it in code for my app, but this should be abstracted to the gem so you can call recipe.abv. 

ABV = (OG-FG)*131
